### PR TITLE
Changed pandas and torch version in environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,19 +7,21 @@ channels:
   - defaults
 dependencies:
   - black>=22.6
-  - python>=3.9
-  - cudatoolkit>=11.3
-  - pytorch>=1.11
+  - python=3.9
+  - cudatoolkit=11.6
+  - pytorch>=1.12.1
   - torchvision>=0.12
   - torchaudio>=0.11
   - pytorch-lightning>=1.6
+  - tensorflow
+  - networkx>=2.8
   - pyg>=2.0
   - pysr>=0.9
   - mygene>=3.2
   - numpy>=1.23
   - scipy>=1.8
   - tqdm>=4.64
-  - pandas>=1.4
+  - pandas=1.4.1
   - scikit-learn>=1.1
   - h5py>=3.7
   - wandb>=0.12


### PR DESCRIPTION
A few issues I was having with the old environment file:
1. Pandas was having issues when generating new datasets with a different edge_tol:
```
File ~/miniconda3/envs/cancernet/lib/python3.9/site-packages/pandas/core/frame.py:639, in DataFrame.__init__(self, data, index, columns, dtype, copy)
    637     raise ValueError("index cannot be a set")
    638 if columns is not None and isinstance(columns, set):
--> 639     raise ValueError("columns cannot be a set")
    641 if copy is None:
    642     if isinstance(data, dict):
    643         # retain pre-GH#38939 default behavior

ValueError: columns cannot be a set
```

which was fixed by setting it to version 1.4.1
2. Torch and cuda were incompatible, and I was having issues on rusty using gpus when using fresh environments from the .yml file:
```
(base) [cpedersen@worker1046 cancer-net]$ conda env create -f environment.yml
...
(base) [cpedersen@worker1046 cancer-net]$ conda activate cancerenv
(cancerenv) [cpedersen@worker1046 cancer-net]$ python3
Python 3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:35:26) [GCC 10.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> torch.cuda.is_available()
False
```
3. Tensorflow (needed to run the old pnet) also had some conflicts with the torch and cuda versions

Have fixed all these with the new yml file and tested in fresh environments. NB that even without the tensorflow consideration, the old environment wasn't working on gpu for me on a fresh install, so I suggest with just use this for now, and drop tensorflow once we have fully validated our torch pnet implementation.