### PR TITLE
Fix CUDA dependencies (and remove optuna)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - scikit-learn>=1.1
   - h5py>=3.7
   - wandb>=0.12
-  - optuna>=2.10
   - matplotlib>=3.5
   - seaborn>=0.11
   - jupyter>=1.0


### PR DESCRIPTION
* fixed `cudatoolkit` version following the issue discovered by Chris (CUDA wasn't working because `pyg` forced an older version of `pytorch` that wasn't compatible with the newest `cudatoolkit`)
* removed `optuna` dependency