### PR TITLE
Fix issue with sparse tensors by using pyg 2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,12 +8,12 @@ channels:
 dependencies:
   - black>=22.6
   - python>=3.9
-  - cudatoolkit=11.6
+  - cudatoolkit=11.3
   - pytorch>=1.11
   - torchvision>=0.12
   - torchaudio>=0.11
   - pytorch-lightning>=1.6
-  - pyg>=2.0
+  - pyg==2.0.4
   - pysr>=0.9
   - mygene>=3.2
   - numpy>=1.23


### PR DESCRIPTION
We noticed a massive slowdown (~20x) after upgrading packages. Turned out to be a regression in `pytorch-geometric` in the handling of sparse tensors (https://github.com/pyg-team/pytorch_geometric/pull/5299). This has been fixed in August but hasn't made it to a release yet, so our best bet was to downgrade `pytorch-geometric` (to `2.0.4`). This also meant we had to use older versions of `pytorch` (`1.11`) and `cudatoolkit` (`11.3`).