### PR TITLE
Add sampler for deterministic sampling of test set

### DIFF
--- a/cancernet/util/sampler.py
+++ b/cancernet/util/sampler.py
@@ -1,0 +1,22 @@
+import torch
+from torch import Tensor
+
+from torch.utils.data.sampler import Sampler
+from typing import Iterator, Sized
+
+class SequenceSampler(Sampler[int]):
+    r"""Samples elements sequentially, always in the same order.
+
+    Args:
+        data_source (Dataset): dataset to sample from
+    """
+    data_source: Sized
+
+    def __init__(self, data_source: Sized) -> None:
+        self.data_source = data_source
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.data_source)
+
+    def __len__(self) -> int:
+        return len(self.data_source)


### PR DESCRIPTION
I want to be able to train models with random initial weights and train/valid/test splits, but test predictions on a deterministic *ordering* of the test set for a given train/valid/test seed, as we are interested in comparing the predictions between models at each specific data sample. Amazingly I couldn't find a torch sampler able to do this, without fixing the global random seed (the [SequentialSampler](https://pytorch.org/cppdocs/api/classtorch_1_1data_1_1samplers_1_1_sequential_sampler.html), which I thought would do this, simply returns indices based on the *length* of the list of indices, it doesn't return a non-shuffled list of the indices themselves, which seems totally useless). So have added one called `SequenceSampler`.